### PR TITLE
Fix bug in spinner css

### DIFF
--- a/src/css/component.css
+++ b/src/css/component.css
@@ -309,7 +309,7 @@
 }
 
 .ui_number_input > input[type="number"]::-webkit-outer-spin-button,
-.ui_number_input > input[type="number"]::-webkit-outer-spin-button {
+.ui_number_input > input[type="number"]::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
 }
@@ -586,13 +586,4 @@
 
 .ui_swatches .swatch.active {
     box-shadow: 0 0 0 3px var(--button-text-color-active) inset, 0 0 0 4px var(--border-color) inset;
-}
-
-/* disabled arrow on input number fields */
-.color_section_channels input::-webkit-outer-spin-button,
-.color_section_channels input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-}
-.color_section_channels input[type=number] {
-    -moz-appearance:textfield; /* Firefox */
 }


### PR DESCRIPTION
You don't need to add the extra CSS.

This was a type-o on my part. I already had the `::-webkit-outer-spin-button` line, I just put "outer" twice. 