### PR TITLE
Fix for pen pressure render after line smoothing implemented

### DIFF
--- a/src/js/tools/brush.js
+++ b/src/js/tools/brush.js
@@ -235,39 +235,41 @@ class Brush_class extends Base_tools_class {
 				this.render_stabilized(ctx, group_data);
 			}
 			else {
-				ctx.beginPath();
-				ctx.moveTo(group_data[0][0], group_data[0][1]);
-				for (var i = 1; i < group_n; i++) {
-					if (group_data[i] === null) {
-						//break
-						ctx.beginPath();
-					}
-					else {
-						//line
+                if (group_data[0]) {
+                    ctx.beginPath();
+                    ctx.moveTo(group_data[0][0], group_data[0][1]);
+                    for (var i = 1; i < group_n; i++) {
+                        if (group_data[i] === null) {
+                            //break
+                            ctx.beginPath();
+                        }
+                        else {
+                            //line
 
-						ctx.lineWidth = group_data[i][2];
+                            ctx.lineWidth = group_data[i][2];
 
-						if (group_data[i - 1] == null && group_data[i + 1] == null) {
-							//exception - point
-							ctx.arc(group_data[i][0], group_data[i][1], size / 2, 0, 2 * Math.PI, false);
-							ctx.fill();
-						}
-						else if (group_data[i - 1] != null) {
-							//lines
-							ctx.lineWidth = group_data[i][2];
-							ctx.beginPath();
-							ctx.moveTo(group_data[i - 1][0], group_data[i - 1][1]);
-							ctx.lineTo(group_data[i][0], group_data[i][1]);
-							ctx.stroke();
-						}
-					}
-				}
-				if (n == 1 || group_data[1] == null) {
-					//point
-					ctx.beginPath();
-					ctx.arc(group_data[0][0], group_data[0][1], size / 2, 0, 2 * Math.PI, false);
-					ctx.fill();
-				}
+                            if (group_data[i - 1] == null && group_data[i + 1] == null) {
+                                //exception - point
+                                ctx.arc(group_data[i][0], group_data[i][1], size / 2, 0, 2 * Math.PI, false);
+                                ctx.fill();
+                            }
+                            else if (group_data[i - 1] != null) {
+                                //lines
+                                ctx.lineWidth = group_data[i][2];
+                                ctx.beginPath();
+                                ctx.moveTo(group_data[i - 1][0], group_data[i - 1][1]);
+                                ctx.lineTo(group_data[i][0], group_data[i][1]);
+                                ctx.stroke();
+                            }
+                        }
+                    }
+                    if (group_data[1] == null) {
+                        //point
+                        ctx.beginPath();
+                        ctx.arc(group_data[0][0], group_data[0][1], size / 2, 0, 2 * Math.PI, false);
+                        ctx.fill();
+                    }
+                }
 			}
 		}
 

--- a/src/js/tools/brush.js
+++ b/src/js/tools/brush.js
@@ -235,41 +235,41 @@ class Brush_class extends Base_tools_class {
 				this.render_stabilized(ctx, group_data);
 			}
 			else {
-                if (group_data[0]) {
-                    ctx.beginPath();
-                    ctx.moveTo(group_data[0][0], group_data[0][1]);
-                    for (var i = 1; i < group_n; i++) {
-                        if (group_data[i] === null) {
-                            //break
-                            ctx.beginPath();
-                        }
-                        else {
-                            //line
+				if (group_data[0]) {
+					ctx.beginPath();
+					ctx.moveTo(group_data[0][0], group_data[0][1]);
+					for (var i = 1; i < group_n; i++) {
+						if (group_data[i] === null) {
+							//break
+							ctx.beginPath();
+						}
+						else {
+							//line
 
-                            ctx.lineWidth = group_data[i][2];
+							ctx.lineWidth = group_data[i][2];
 
-                            if (group_data[i - 1] == null && group_data[i + 1] == null) {
-                                //exception - point
-                                ctx.arc(group_data[i][0], group_data[i][1], size / 2, 0, 2 * Math.PI, false);
-                                ctx.fill();
-                            }
-                            else if (group_data[i - 1] != null) {
-                                //lines
-                                ctx.lineWidth = group_data[i][2];
-                                ctx.beginPath();
-                                ctx.moveTo(group_data[i - 1][0], group_data[i - 1][1]);
-                                ctx.lineTo(group_data[i][0], group_data[i][1]);
-                                ctx.stroke();
-                            }
-                        }
-                    }
-                    if (group_data[1] == null) {
-                        //point
-                        ctx.beginPath();
-                        ctx.arc(group_data[0][0], group_data[0][1], size / 2, 0, 2 * Math.PI, false);
-                        ctx.fill();
-                    }
-                }
+							if (group_data[i - 1] == null && group_data[i + 1] == null) {
+								//exception - point
+								ctx.arc(group_data[i][0], group_data[i][1], size / 2, 0, 2 * Math.PI, false);
+								ctx.fill();
+							}
+							else if (group_data[i - 1] != null) {
+								//lines
+								ctx.lineWidth = group_data[i][2];
+								ctx.beginPath();
+								ctx.moveTo(group_data[i - 1][0], group_data[i - 1][1]);
+								ctx.lineTo(group_data[i][0], group_data[i][1]);
+								ctx.stroke();
+							}
+						}
+					}
+					if (group_data[1] == null) {
+						//point
+						ctx.beginPath();
+						ctx.arc(group_data[0][0], group_data[0][1], size / 2, 0, 2 * Math.PI, false);
+						ctx.fill();
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
The pen pressure option wasn't working at all,
- render() was called before group_data has any items which threw an error. I put a check in `if (group_data[0]) {`
- When drawing a point, `n == 1` was unnecessary. It draws a point at the beginning of the first line, which then disappears when you draw a second line.

The diff looks confusing because the line indentation changed.