### PR TITLE
Fix icon button with image vertical align

### DIFF
--- a/src/css/component.css
+++ b/src/css/component.css
@@ -203,15 +203,21 @@
 
 .ui_icon_button {
     height: 2.8rem;
+    line-height: 2.8rem;
 }
 
 .ui_icon_button.input_height {
     height: 2.4rem;
+    line-height: 2.4rem;
 }
 
 .ui_icon_button > svg {
     display: block;
     font-size: 1.6rem;
+}
+.ui_icon_button > img {
+    display: block;
+    margin: 0 auto;
 }
 button img{
     filter: var(--menu-icons-filter);

--- a/src/js/core/gui/gui-tools.js
+++ b/src/js/core/gui/gui-tools.js
@@ -214,7 +214,7 @@ class GUI_tools_class {
 					element.classList.add('ui_icon_button');
 					element.classList.add('input_height');
 					element.innerHTML = icon;
-					element.innerHTML = '<img alt="" src="images/icons/'+icon+'" />';
+					element.innerHTML = '<img alt="'+title+'" src="images/icons/'+icon+'" />';
 				} else {
 					element.classList.add('ui_toggle_button');
 				}


### PR DESCRIPTION
Icons weren't vertically centered after switch to img tag. 

![image](https://user-images.githubusercontent.com/4075314/100002139-27bb6600-2d92-11eb-8207-8be6a4d587bd.png)

![image](https://user-images.githubusercontent.com/4075314/100002194-373aaf00-2d92-11eb-8aaa-9e4a8441eeec.png)

Also need to put readable text inside all buttons and links for screen readers.  Image alt tag works fine for this.