### PR TITLE
Backwards compatibility align format

### DIFF
--- a/src/js/tools/text.js
+++ b/src/js/tools/text.js
@@ -1376,10 +1376,12 @@ class Text_editor_class {
 						if (largestOffset > totalTextDirectionSize) {
 							totalTextDirectionSize = largestOffset;
 						}
-						lineWraps.push({
+						const newWrap = {
 							characterOffsets: wrapCharacterOffsets,
 							spans: beforeSpans
-						});
+						};
+						newWrap.characterOffsets = newWrap.characterOffsets.slice(0, this.get_wrap_text(newWrap).length + 1);
+						lineWraps.push(newWrap);
 						currentWrapSpans = afterSpans;
 						wrapAccumulativeSize = 0;
 						wrapCharacterOffsets = [0];
@@ -1415,7 +1417,8 @@ class Text_editor_class {
 			for (let line of lineRenderInfo.lines) {
 				for (let wrap of line.wraps) {
 					const isCentered = (isHorizontalTextDirection && halign == 'center') || (!isHorizontalTextDirection && valign === 'middle');
-					const wrapSize = wrap.characterOffsets[wrap.characterOffsets.length - 1];
+					const lastSpan = wrap.spans[wrap.spans.length - 1];
+					const wrapSize = wrap.characterOffsets[wrap.characterOffsets.length - 1 - (lastSpan.text[lastSpan.text.length - 1] === ' ' ? 1 : 0)];
 					const startOffset = (isCentered ? maxTextDirectionSize / 2 : maxTextDirectionSize) - (isCentered ? wrapSize / 2 : wrapSize);
 					if (startOffset > 0) {
 						for (let oi = 0; oi < wrap.characterOffsets.length; oi++) {

--- a/src/js/tools/text.js
+++ b/src/js/tools/text.js
@@ -2196,7 +2196,7 @@ class Text_class extends Base_tools_class {
 					]);
 				}
 				params.boundary = 'box';
-				params.halign = params.align ? params.align.value.toLowerCase() : 'left';
+				params.halign = params.align ? (params.align.value ? params.align.value : params.align).toLowerCase() : 'left';
 				params.valign = 'top';
 				params.text_direction = 'ltr';
 				params.wrap_direction = 'ttb';


### PR DESCRIPTION
If I save a text file in https://viliusle.github.io/miniPaint/

It stores the value in `params.align`, not `params.align.value`. Looks like both were a possibility?

PR also fixes text centering when a space causes the wrap (it's not offset to the left anymore).