### PR TITLE
Text tool - Add leading and detect kerning from font

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -207,6 +207,12 @@ config.TOOLS = [
 				min: -999,
 				max: 999,
 				step: 1
+			},
+			leading: {
+				value: 0,
+				min: -999,
+				max: 999,
+				step: 1
 			}
 		},
 	},

--- a/src/js/core/base-selection.js
+++ b/src/js/core/base-selection.js
@@ -263,6 +263,7 @@ class Base_selection_class {
 			};
 		}
 		if (e.type == 'mousemove' && this.mouse_lock == 'selected_object_actions') {
+			const allowNegativeDimensions = settings.data.render_function && ['line', 'gradient'].includes(settings.data.render_function[0]);
 			mainWrapper.style.cursor = "pointer";
 			
 			var is_ctrl = false;
@@ -313,21 +314,23 @@ class Base_selection_class {
 				if (is_drag_type_top || is_drag_type_bottom)
 					settings.data.height = height;
 				
-				// Don't allow negative width/height
-				if (settings.data.width <= 0) {
-					settings.data.width = Math.abs(settings.data.width);
-					if (is_drag_type_left) {
-						settings.data.x -= settings.data.width;
-					} else {
-						settings.data.x = this.click_details.x - settings.data.width;
+				// Don't allow negative width/height on most layers
+				if (!allowNegativeDimensions) {
+					if (settings.data.width <= 0) {
+						settings.data.width = Math.abs(settings.data.width);
+						if (is_drag_type_left) {
+							settings.data.x -= settings.data.width;
+						} else {
+							settings.data.x = this.click_details.x - settings.data.width;
+						}
 					}
-				}
-				if (settings.data.height <= 0) {
-					settings.data.height = Math.abs(settings.data.height);
-					if (is_drag_type_top) {
-						settings.data.y -= settings.data.height;
-					} else {
-						settings.data.y = this.click_details.y - settings.data.height;
+					if (settings.data.height <= 0) {
+						settings.data.height = Math.abs(settings.data.height);
+						if (is_drag_type_top) {
+							settings.data.y -= settings.data.height;
+						} else {
+							settings.data.y = this.click_details.y - settings.data.height;
+						}
 					}
 				}
 				config.need_render = true;

--- a/src/js/core/gui/gui-details.js
+++ b/src/js/core/gui/gui-details.js
@@ -53,6 +53,13 @@ var template = `
 				<option value="dynamic">Dynamic</option>
 			</select>
 		</div>
+		<div class="row">
+			<span class="trn label" title="Auto Kerning">Kerning:</span>
+			<select id="detail_param_kerning">
+				<option value="none">None</option>
+				<option value="metrics">Metrics</option>
+			</select>
+		</div>
 		<div class="row" hidden> <!-- Future implementation -->
 			<span class="trn label">Direction:</span>
 			<select id="detail_param_text_direction">
@@ -135,6 +142,7 @@ class GUI_details_class {
 		}
 		this.render_text(events);
 		this.render_general_select_param('boundary', events);
+		this.render_general_select_param('kerning', events);
 		this.render_general_select_param('text_direction', events);
 		this.render_general_select_param('wrap', events);
 		this.render_general_select_param('wrap_direction', events);

--- a/src/js/tools/text.js
+++ b/src/js/tools/text.js
@@ -1735,6 +1735,7 @@ class Text_editor_class {
 							ctx.strokeStyle = strokeStyle;
 							ctx.fillText(letter, letterDrawX, letterDrawY);
 							if (stroke_size) {
+								ctx.lineWidth = stroke_size;
 								ctx.strokeText(letter, letterDrawX, letterDrawY);
 							}
 							if (strikethrough) {


### PR DESCRIPTION
#185

- Fixes line height calculation bug, uses largest ascender and largest descender on the line (if they happen to be two separate characters, one pushing the line up or down further than the other), instead of just finding the one character that has the largest overall height irregardless of the baseline. This was only noticable when you have two fonts where one has a significantly larger descender even at a smaller total line height, such as "Indie Flower" + "Arial".
- Add support to detect and cache kerning pairs from font. Can turn this off.
- Line leading control added, which works as a top offset. 
- Updated legacy file conversion code to adjust leading and layer position so the files match as visually close as possible.