### PR TITLE
Restyle selection to make it work easier with text and smaller layers

### DIFF
--- a/src/js/core/base-selection.js
+++ b/src/js/core/base-selection.js
@@ -187,15 +187,16 @@ class Base_selection_class {
 
 		const wholeLineWidth = 2 / config.ZOOM;
 		const halfLineWidth = wholeLineWidth / 2;
+		const doubleLineWidth = wholeLineWidth * 2;
 
 		//borders
 		if (settings.enable_borders == true && (x != 0 || y != 0 || w != config.WIDTH || h != config.HEIGHT)) {
+			this.ctx.lineWidth = doubleLineWidth;
+			this.ctx.strokeStyle = '#ffffff';
+			this.ctx.strokeRect(x - wholeLineWidth, y - wholeLineWidth, w + doubleLineWidth, h + doubleLineWidth);
 			this.ctx.lineWidth = wholeLineWidth;
-			this.ctx.strokeStyle = 'rgb(255, 255, 255)';
-			this.ctx.strokeRect(x - halfLineWidth, y - halfLineWidth, w + wholeLineWidth, h + wholeLineWidth);
-			this.ctx.lineWidth = halfLineWidth;
-			this.ctx.strokeStyle = 'rgb(0, 0, 0)';
-			this.ctx.strokeRect(x - wholeLineWidth, y - wholeLineWidth, w + (wholeLineWidth * 2), h + (wholeLineWidth * 2));
+			this.ctx.strokeStyle = '#008800';
+			this.ctx.strokeRect(x - wholeLineWidth, y - wholeLineWidth, w + doubleLineWidth, h + doubleLineWidth);
 		}
 
 		const hitsLeftEdge = x < handle_size;
@@ -229,11 +230,15 @@ class Base_selection_class {
 			}
 
 			//borders
-			this.ctx.lineWidth = wholeLineWidth;
+			this.ctx.lineWidth = halfLineWidth;
 			this.ctx.beginPath();
 			this.ctx.arc(x + dx * block_size, y + dy * block_size, block_size / 2, 0, 2 * Math.PI);
 			this.ctx.fill();
 			this.ctx.stroke();
+			this.ctx.beginPath();
+			this.ctx.fillStyle = "#008800";
+			this.ctx.arc(x + dx * block_size, y + dy * block_size, block_size / 2.8, 0, 2 * Math.PI);
+			this.ctx.fill();
 		};
 
 		if (settings.enable_controls == true) {

--- a/src/js/core/base-selection.js
+++ b/src/js/core/base-selection.js
@@ -171,8 +171,10 @@ class Base_selection_class {
 
 		this.ctx.save();
 		this.ctx.globalAlpha = 1;
+		let isRotated = false;
 		if (data.rotate != null && data.rotate != 0) {
 			//rotate
+			isRotated = true;
 			this.ctx.translate(data.x + data.width / 2, data.y + data.height / 2);
 			this.ctx.rotate(data.rotate * Math.PI / 180);
 			x = Math.round(-data.width / 2);
@@ -199,11 +201,10 @@ class Base_selection_class {
 			this.ctx.strokeRect(x - wholeLineWidth, y - wholeLineWidth, w + doubleLineWidth, h + doubleLineWidth);
 		}
 
-		const hitsLeftEdge = x < handle_size;
-		const hitsTopEdge = y < handle_size;
-		const hitsRightEdge = x + w > config.WIDTH - handle_size;
-		const hitsBottomEdge = y + h > config.HEIGHT - handle_size;
-		const hitsAnyEdge = hitsLeftEdge || hitsTopEdge || hitsRightEdge || hitsBottomEdge;
+		const hitsLeftEdge = isRotated ? false : x < handle_size;
+		const hitsTopEdge = isRotated ? false : y < handle_size;
+		const hitsRightEdge = isRotated ? false : x + w > config.WIDTH - handle_size;
+		const hitsBottomEdge = isRotated ? false : y + h > config.HEIGHT - handle_size;
 
 		//draw corners
 		var corner = (x, y, dx, dy, drag_type) => {
@@ -220,9 +221,11 @@ class Base_selection_class {
 				size: block_size,
 			};
 
+			let fillColor = "#008800";
 			if (settings.enable_controls == false || angle > 0) {
 				this.ctx.strokeStyle = "rgba(0, 0, 0, 0.4)";
 				this.ctx.fillStyle = "rgba(255, 255, 255, 0.8)";
+				fillColor = "rgba(0, 127, 0, 0.4)";
 			}
 			else {
 				this.ctx.strokeStyle = "#000000";
@@ -236,7 +239,7 @@ class Base_selection_class {
 			this.ctx.fill();
 			this.ctx.stroke();
 			this.ctx.beginPath();
-			this.ctx.fillStyle = "#008800";
+			this.ctx.fillStyle = fillColor;
 			this.ctx.arc(x + dx * block_size, y + dy * block_size, block_size / 2.8, 0, 2 * Math.PI);
 			this.ctx.fill();
 		};

--- a/src/js/core/base-selection.js
+++ b/src/js/core/base-selection.js
@@ -210,7 +210,7 @@ class Base_selection_class {
 		var corner = (x, y, dx, dy, drag_type) => {
 			// var block_size = Math.round(block_size_default / 2) * 2;
 			var angle = 0;
-			if (settings.data.rotate != null && settings.data.rotate > 0) {
+			if (settings.data.rotate != null && settings.data.rotate != 0) {
 				angle = settings.data.rotate;
 			}
 
@@ -222,7 +222,7 @@ class Base_selection_class {
 			};
 
 			let fillColor = "#008800";
-			if (settings.enable_controls == false || angle > 0) {
+			if (settings.enable_controls == false || angle != 0) {
 				this.ctx.strokeStyle = "rgba(0, 0, 0, 0.4)";
 				this.ctx.fillStyle = "rgba(255, 255, 255, 0.8)";
 				fillColor = "rgba(0, 127, 0, 0.4)";

--- a/src/js/core/base-selection.js
+++ b/src/js/core/base-selection.js
@@ -8,6 +8,8 @@ import config from './../config.js';
 var instance = null;
 var settings_all = [];
 
+const handle_size = 12;
+
 const DRAG_TYPE_TOP = 1;
 const DRAG_TYPE_BOTTOM = 2;
 const DRAG_TYPE_LEFT = 4;
@@ -137,7 +139,6 @@ class Base_selection_class {
 	 * marks object as selected, and draws corners
 	 */
 	draw_selection() {
-		var _this = this;
 		var settings = this.find_settings();
 		var data = settings.data;
 
@@ -156,8 +157,7 @@ class Base_selection_class {
 			return;
 		}
 
-		var block_size_default = 14;
-		block_size_default = Math.ceil(block_size_default / config.ZOOM);
+		var block_size_default = handle_size / config.ZOOM;
 
 		if (config.ZOOM != 1) {
 			x = Math.round(x);
@@ -166,7 +166,6 @@ class Base_selection_class {
 			h = Math.round(h);
 		}
 		var block_size = block_size_default;
-		var half_size = Math.ceil(block_size / 2);
 
 		this.ctx.save();
 		this.ctx.globalAlpha = 1;
@@ -178,77 +177,78 @@ class Base_selection_class {
 			y = Math.round(-data.height / 2);
 		}
 		
-		var half_fix = 0.5;
-
 		//fill
 		if (settings.enable_background == true) {
 			this.ctx.fillStyle = "rgba(0, 255, 0, 0.3)";
 			this.ctx.fillRect(x, y, w, h);
 		}
 
+		const wholeLineWidth = 2 / config.ZOOM;
+		const halfLineWidth = wholeLineWidth / 2;
+
 		//borders
 		if (settings.enable_borders == true && (x != 0 || y != 0 || w != config.WIDTH || h != config.HEIGHT)) {
-			this.ctx.lineWidth = 1;
-			this.ctx.strokeStyle = "rgba(0, 128, 0, 0.5)";
-			this.ctx.strokeRect(x + half_fix, y + half_fix, w, h);
+			this.ctx.lineWidth = wholeLineWidth;
+			this.ctx.strokeStyle = 'rgb(255, 255, 255)';
+			this.ctx.strokeRect(x - halfLineWidth, y - halfLineWidth, w + wholeLineWidth, h + wholeLineWidth);
+			this.ctx.lineWidth = halfLineWidth;
+			this.ctx.strokeStyle = 'rgb(0, 0, 0)';
+			this.ctx.strokeRect(x - wholeLineWidth, y - wholeLineWidth, w + (wholeLineWidth * 2), h + (wholeLineWidth * 2));
 		}
 
 		//draw corners
-		if (settings.enable_controls == true && Math.abs(w) > block_size * 2 && Math.abs(h) > block_size * 2) {
-			corner(x - half_size, y - half_size, 0, 0, DRAG_TYPE_LEFT | DRAG_TYPE_TOP);
-			corner(x + w + half_size, y - half_size, -1, 0, DRAG_TYPE_RIGHT | DRAG_TYPE_TOP);
-			corner(x - half_size, y + h + half_size, 0, -1, DRAG_TYPE_LEFT | DRAG_TYPE_BOTTOM);
-			corner(x + w + half_size, y + h + half_size, -1, -1, DRAG_TYPE_RIGHT | DRAG_TYPE_BOTTOM);
-		}
-
-		if (settings.enable_controls == true) {
-			//draw centers
-			if (Math.abs(w) > block_size * 5) {
-				corner(x + w / 2 - block_size / 2, y - half_size, 0, 0, DRAG_TYPE_TOP);
-				corner(x + w / 2 - block_size / 2, y + h + half_size, 0, -1, DRAG_TYPE_BOTTOM);
-			}
-			if (Math.abs(h) > block_size * 5) {
-				corner(x - half_size, y + h / 2 - block_size / 2, 0, 0, DRAG_TYPE_LEFT);
-				corner(x + w + half_size, y + h / 2 - block_size / 2, -1, 0, DRAG_TYPE_RIGHT);
-			}
-		}
-
-		function corner(x, y, dx, dy, drag_type) {
-			var block_size = Math.round(block_size_default / 2) * 2;
-			x = Math.round(x);
-			y = Math.round(y);
+		var corner = (x, y, dx, dy, drag_type) => {
+			// var block_size = Math.round(block_size_default / 2) * 2;
 			var angle = 0;
 			if (settings.data.rotate != null && settings.data.rotate > 0) {
 				angle = settings.data.rotate;
 			}
 
 			//register position
-			_this.selected_obj_positions[drag_type] = {
+			this.selected_obj_positions[drag_type] = {
 				x: x + dx * block_size,
 				y: y + dy * block_size,
 				size: block_size,
 			};
 
 			if (settings.enable_controls == false || angle > 0) {
-				_this.ctx.strokeStyle = "rgba(0, 128, 0, 0.4)";
-				_this.ctx.fillStyle = "rgba(255, 255, 255, 0.8)";
+				this.ctx.strokeStyle = "rgba(0, 0, 0, 0.4)";
+				this.ctx.fillStyle = "rgba(255, 255, 255, 0.8)";
 			}
 			else {
-				_this.ctx.strokeStyle = "#008000";
-				_this.ctx.fillStyle = "#ffffff";
+				this.ctx.strokeStyle = "#000000";
+				this.ctx.fillStyle = "#ffffff";
 			}
 
 			//borders
-			_this.ctx.lineWidth = 1;
-			if (config.ZOOM < 1)
-				_this.ctx.lineWidth = 2;
-			_this.ctx.beginPath();
-			_this.ctx.arc(
-				x + dx * block_size + half_size,
-				y + dy * block_size + half_size,
-				half_size, 0, 2 * Math.PI);
-			_this.ctx.fill();
-			_this.ctx.stroke();
+			this.ctx.lineWidth = halfLineWidth;
+			this.ctx.fillRect(x + dx * block_size, y + dy * block_size, block_size, block_size);
+			this.ctx.strokeRect(x + dx * block_size, y + dy * block_size, block_size, block_size);
+		};
+
+		const hitsLeftEdge = x < block_size;
+		const hitsTopEdge = y < block_size;
+		const hitsRightEdge = x + w > config.WIDTH - block_size;
+		const hitsBottomEdge = y + h > config.HEIGHT - block_size;
+		const hitsAnyEdge = hitsLeftEdge || hitsTopEdge || hitsRightEdge || hitsBottomEdge;
+
+		if (settings.enable_controls == true) {
+			corner(x - block_size - wholeLineWidth, y - block_size - wholeLineWidth, hitsAnyEdge ? 1 : 0, hitsAnyEdge ? 1 : 0, DRAG_TYPE_LEFT | DRAG_TYPE_TOP);
+			corner(x + w + wholeLineWidth, y - block_size - wholeLineWidth, hitsAnyEdge ? -1 : 0, hitsAnyEdge ? 1 : 0, DRAG_TYPE_RIGHT | DRAG_TYPE_TOP);
+			corner(x - block_size - wholeLineWidth, y + h + wholeLineWidth, hitsAnyEdge ? 1 : 0, hitsAnyEdge ? -1 : 0, DRAG_TYPE_LEFT | DRAG_TYPE_BOTTOM);
+			corner(x + w + wholeLineWidth, y + h + wholeLineWidth, hitsAnyEdge ? -1 : 0, hitsAnyEdge ? -1 : 0, DRAG_TYPE_RIGHT | DRAG_TYPE_BOTTOM);
+		}
+
+		if (settings.enable_controls == true) {
+			//draw centers
+			if (Math.abs(w) > block_size * 5) {
+				corner(x + w / 2 - block_size / 2, y - block_size - wholeLineWidth, 0, hitsAnyEdge ? 1 : 0, DRAG_TYPE_TOP);
+				corner(x + w / 2 - block_size / 2, y + h + wholeLineWidth, 0, hitsAnyEdge ? -1 : 0, DRAG_TYPE_BOTTOM);
+			}
+			if (Math.abs(h) > block_size * 5) {
+				corner(x - block_size - wholeLineWidth, y + h / 2 - block_size / 2, hitsAnyEdge ? 1 : 0, 0, DRAG_TYPE_LEFT);
+				corner(x + w + wholeLineWidth, y + h / 2 - block_size / 2, hitsAnyEdge ? -1 : 0, 0, DRAG_TYPE_RIGHT);
+			}
 		}
 
 		//restore

--- a/src/js/core/base-selection.js
+++ b/src/js/core/base-selection.js
@@ -166,6 +166,8 @@ class Base_selection_class {
 			h = Math.round(h);
 		}
 		var block_size = block_size_default;
+		var corner_offset = (block_size / 2.4);
+		var middle_offset = (block_size / 1.9);
 
 		this.ctx.save();
 		this.ctx.globalAlpha = 1;
@@ -227,33 +229,29 @@ class Base_selection_class {
 			}
 
 			//borders
-			this.ctx.lineWidth = halfLineWidth;
-			if (hitsAnyEdge) {
-				this.ctx.globalCompositeOperation = 'difference';
-			}
-			this.ctx.fillRect(x + dx * block_size, y + dy * block_size, block_size, block_size);
-			if (hitsAnyEdge) {
-				this.ctx.globalCompositeOperation = 'source-over';
-			}
-			this.ctx.strokeRect(x + dx * block_size, y + dy * block_size, block_size, block_size);
+			this.ctx.lineWidth = wholeLineWidth;
+			this.ctx.beginPath();
+			this.ctx.arc(x + dx * block_size, y + dy * block_size, block_size / 2, 0, 2 * Math.PI);
+			this.ctx.fill();
+			this.ctx.stroke();
 		};
 
 		if (settings.enable_controls == true) {
-			corner(x - block_size - wholeLineWidth, y - block_size - wholeLineWidth, hitsAnyEdge ? 1 : 0, hitsAnyEdge ? 1 : 0, DRAG_TYPE_LEFT | DRAG_TYPE_TOP);
-			corner(x + w + wholeLineWidth, y - block_size - wholeLineWidth, hitsAnyEdge ? -1 : 0, hitsAnyEdge ? 1 : 0, DRAG_TYPE_RIGHT | DRAG_TYPE_TOP);
-			corner(x - block_size - wholeLineWidth, y + h + wholeLineWidth, hitsAnyEdge ? 1 : 0, hitsAnyEdge ? -1 : 0, DRAG_TYPE_LEFT | DRAG_TYPE_BOTTOM);
-			corner(x + w + wholeLineWidth, y + h + wholeLineWidth, hitsAnyEdge ? -1 : 0, hitsAnyEdge ? -1 : 0, DRAG_TYPE_RIGHT | DRAG_TYPE_BOTTOM);
+			corner(x - corner_offset - wholeLineWidth, y - corner_offset - wholeLineWidth, hitsLeftEdge ? 0.5 : 0, hitsTopEdge ? 0.5 : 0, DRAG_TYPE_LEFT | DRAG_TYPE_TOP);
+			corner(x + w + corner_offset + wholeLineWidth, y - corner_offset - wholeLineWidth, hitsRightEdge ? -0.5 : 0, hitsTopEdge ? 0.5 : 0, DRAG_TYPE_RIGHT | DRAG_TYPE_TOP);
+			corner(x - corner_offset - wholeLineWidth, y + h + corner_offset + wholeLineWidth, hitsLeftEdge ? 0.5 : 0, hitsBottomEdge ? -0.5 : 0, DRAG_TYPE_LEFT | DRAG_TYPE_BOTTOM);
+			corner(x + w + corner_offset + wholeLineWidth, y + h + corner_offset + wholeLineWidth, hitsRightEdge ? -0.5 : 0, hitsBottomEdge ? -0.5 : 0, DRAG_TYPE_RIGHT | DRAG_TYPE_BOTTOM);
 		}
 
 		if (settings.enable_controls == true) {
 			//draw centers
 			if (Math.abs(w) > block_size * 5) {
-				corner(x + w / 2 - block_size / 2, y - block_size - wholeLineWidth, 0, hitsAnyEdge ? 1 : 0, DRAG_TYPE_TOP);
-				corner(x + w / 2 - block_size / 2, y + h + wholeLineWidth, 0, hitsAnyEdge ? -1 : 0, DRAG_TYPE_BOTTOM);
+				corner(x + w / 2, y - middle_offset - wholeLineWidth, 0, hitsTopEdge ? 0.5 : 0, DRAG_TYPE_TOP);
+				corner(x + w / 2, y + h + middle_offset + wholeLineWidth, 0, hitsBottomEdge ? -0.5 : 0, DRAG_TYPE_BOTTOM);
 			}
 			if (Math.abs(h) > block_size * 5) {
-				corner(x - block_size - wholeLineWidth, y + h / 2 - block_size / 2, hitsAnyEdge ? 1 : 0, 0, DRAG_TYPE_LEFT);
-				corner(x + w + wholeLineWidth, y + h / 2 - block_size / 2, hitsAnyEdge ? -1 : 0, 0, DRAG_TYPE_RIGHT);
+				corner(x - middle_offset - wholeLineWidth, y + h / 2, hitsLeftEdge ? 0.5 : 0, 0, DRAG_TYPE_LEFT);
+				corner(x + w + middle_offset + wholeLineWidth, y + h / 2, hitsRightEdge ? -0.5 : 0, 0, DRAG_TYPE_RIGHT);
 			}
 		}
 
@@ -312,7 +310,7 @@ class Base_selection_class {
 			const is_drag_type_bottom = Math.floor(drag_type / DRAG_TYPE_BOTTOM) % 2 === 1;
 			
 			if (e.buttons == 1 || typeof e.buttons == "undefined") {
-				// Do transformations				
+				// Do transformations
 				var dx = Math.round(mouse.x - mouse.click_x);
 				var dy = Math.round(mouse.y - mouse.click_y);
 				var width = this.click_details.width + dx;
@@ -381,8 +379,8 @@ class Base_selection_class {
 			for (let current_drag_type in this.selected_obj_positions) {
 				const position = this.selected_obj_positions[current_drag_type];
 
-				if (mouse.x >= position.x && mouse.x <= position.x + position.size
-					&& mouse.y >= position.y && mouse.y <= position.y + position.size
+				if (mouse.x >= position.x - position.size / 2 && mouse.x <= position.x + position.size / 2
+					&& mouse.y >= position.y - position.size / 2 && mouse.y <= position.y + position.size / 2
 					) {
 					//match
 					if (event_type == 'mousedown') {

--- a/src/js/core/base-selection.js
+++ b/src/js/core/base-selection.js
@@ -196,6 +196,12 @@ class Base_selection_class {
 			this.ctx.strokeRect(x - wholeLineWidth, y - wholeLineWidth, w + (wholeLineWidth * 2), h + (wholeLineWidth * 2));
 		}
 
+		const hitsLeftEdge = x < handle_size;
+		const hitsTopEdge = y < handle_size;
+		const hitsRightEdge = x + w > config.WIDTH - handle_size;
+		const hitsBottomEdge = y + h > config.HEIGHT - handle_size;
+		const hitsAnyEdge = hitsLeftEdge || hitsTopEdge || hitsRightEdge || hitsBottomEdge;
+
 		//draw corners
 		var corner = (x, y, dx, dy, drag_type) => {
 			// var block_size = Math.round(block_size_default / 2) * 2;
@@ -222,15 +228,15 @@ class Base_selection_class {
 
 			//borders
 			this.ctx.lineWidth = halfLineWidth;
+			if (hitsAnyEdge) {
+				this.ctx.globalCompositeOperation = 'difference';
+			}
 			this.ctx.fillRect(x + dx * block_size, y + dy * block_size, block_size, block_size);
+			if (hitsAnyEdge) {
+				this.ctx.globalCompositeOperation = 'source-over';
+			}
 			this.ctx.strokeRect(x + dx * block_size, y + dy * block_size, block_size, block_size);
 		};
-
-		const hitsLeftEdge = x < block_size;
-		const hitsTopEdge = y < block_size;
-		const hitsRightEdge = x + w > config.WIDTH - block_size;
-		const hitsBottomEdge = y + h > config.HEIGHT - block_size;
-		const hitsAnyEdge = hitsLeftEdge || hitsTopEdge || hitsRightEdge || hitsBottomEdge;
 
 		if (settings.enable_controls == true) {
 			corner(x - block_size - wholeLineWidth, y - block_size - wholeLineWidth, hitsAnyEdge ? 1 : 0, hitsAnyEdge ? 1 : 0, DRAG_TYPE_LEFT | DRAG_TYPE_TOP);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4075314/100963604-b055a700-34f4-11eb-9254-a34394141e16.png)

![image](https://user-images.githubusercontent.com/4075314/100964421-96b55f00-34f6-11eb-9b13-439a18ee1918.png)

- Makes selection outline more visible against both dark and light colors
- Selection outline increases in size when zooming out for visibility
- Resize handles are on the outside of the selection by default so they don't interfere with layer editing
- Handles move inside the layer when near the edge of canvas
- Corner handles are always visible so it never becomes impossible to resize with mouse when very small