### PR TITLE
Pixel Snap Rectangle Tool

### DIFF
--- a/src/js/config.js
+++ b/src/js/config.js
@@ -150,7 +150,10 @@ config.TOOLS = [
 		title: 'Rectangle',
 		attributes: {
 			size: 1,
-			radius: 0,
+			radius: {
+				value: 0,
+				min: 0,
+			},
 			fill: true,
 			square: false,
 		},

--- a/src/js/core/base-tools.js
+++ b/src/js/core/base-tools.js
@@ -274,7 +274,21 @@ class Base_tools_class {
 	}
 
 	getParams() {
-		return config.TOOL.attributes;
+		const params = {};
+		// Number inputs return the .value if defined as objects.
+		for (let attributeName in config.TOOL.attributes) {
+			const attribute = config.TOOL.attributes[attributeName];
+			if (!isNaN(attribute.value) && attribute.value != null) {
+				if (typeof attribute.value === 'string') {
+					params[attributeName] = attribute;
+				} else {
+					params[attributeName] = attribute.value;
+				}
+			} else {
+				params[attributeName] = attribute;
+			}
+		}
+		return params;
 	}
 
 	adaptSize(value, type = "width") {

--- a/src/js/tools/rectangle.js
+++ b/src/js/tools/rectangle.js
@@ -89,25 +89,32 @@ class Rectangle_class extends Base_tools_class {
 			return;
 		}
 
-		var width = Math.round(mouse.x) - this.layer.x;
-		var height = Math.round(mouse.y) - this.layer.y;
+		var mouse_x = Math.round(mouse.x);
+		var mouse_y = Math.round(mouse.y);
+		var click_x = Math.round(mouse.click_x);
+		var click_y = Math.round(mouse.click_y);
+		var x = Math.min(mouse_x, click_x);
+		var y = Math.min(mouse_y, click_y);
+		var width = Math.abs(mouse_x - click_x);
+		var height = Math.abs(mouse_y - click_y);
 
 		if (params.square == true) {
-			if (Math.abs(width) < Math.abs(height)) {
-				if (width > 0)
-					width = Math.abs(height);
-				else
-					width = -Math.abs(height);
+			if (width < height) {
+				width = height;
+			} else {
+				height = width;
 			}
-			else {
-				if (height > 0)
-					height = Math.abs(width);
-				else
-					height = -Math.abs(width);
+			if (mouse_x < click_x) {
+				x = click_x - width;
+			}
+			if (mouse_y < click_y) {
+				y = click_y - height;
 			}
 		}
 
 		//more data
+		config.layer.x = x;
+		config.layer.y = y;
 		config.layer.width = width;
 		config.layer.height = height;
 		this.Base_layers.render();
@@ -121,22 +128,27 @@ class Rectangle_class extends Base_tools_class {
 			config.layer.status = null;
 			return;
 		}
-
-		var width = Math.round(mouse.x) - this.layer.x;
-		var height = Math.round(mouse.y) - this.layer.y;
+		
+		var mouse_x = Math.round(mouse.x);
+		var mouse_y = Math.round(mouse.y);
+		var click_x = Math.round(mouse.click_x);
+		var click_y = Math.round(mouse.click_y);
+		var x = Math.min(mouse_x, click_x);
+		var y = Math.min(mouse_y, click_y);
+		var width = Math.abs(mouse_x - click_x);
+		var height = Math.abs(mouse_y - click_y);
 
 		if (params.square == true) {
-			if (Math.abs(width) < Math.abs(height)) {
-				if (width > 0)
-					width = Math.abs(height);
-				else
-					width = -Math.abs(height);
+			if (width < height) {
+				width = height;
+			} else {
+				height = width;
 			}
-			else {
-				if (height > 0)
-					height = Math.abs(width);
-				else
-					height = -Math.abs(width);
+			if (mouse_x < click_x) {
+				x = click_x - width;
+			}
+			if (mouse_y < click_y) {
+				y = click_y - height;
 			}
 		}
 
@@ -147,6 +159,8 @@ class Rectangle_class extends Base_tools_class {
 		}
 
 		//more data
+		config.layer.x = x;
+		config.layer.y = y;
 		config.layer.width = width;
 		config.layer.height = height;
 		config.layer.status = null;
@@ -182,35 +196,6 @@ class Rectangle_class extends Base_tools_class {
 	}
 
 	/**
-	 * draws rectangle
-	 * 
-	 * @param {CanvasRenderingContext2D} ctx
-	 * @param {Number} x
-	 * @param {Number} y
-	 * @param {Number} width
-	 * @param {Number} height
-	 * @param {Boolean} fill
-	 */
-	rectangle(ctx, x, y, width, height, fill) {
-		x = x + 0.5;
-		y = y + 0.5;
-		width--;
-		height--;
-		if (typeof fill == "undefined")
-			fill = false;
-
-		ctx.beginPath();
-		ctx.rect(x, y, width, height);
-
-		if (fill) {
-			ctx.fill();
-		}
-		else {
-			ctx.stroke();
-		}
-	}
-	
-	/**
 	 * Draws a rounded rectangle on canvas.
 	 * 
 	 * @param {CanvasRenderingContext2D} ctx
@@ -234,7 +219,8 @@ class Rectangle_class extends Base_tools_class {
 			height = Math.abs(height);
 			y = y - height;
 		}
-		
+		var smaller_dimension = Math.min(width, height);
+
 		radius = parseInt(radius);
 		if (typeof fill == 'undefined') {
 			fill = false;
@@ -252,19 +238,22 @@ class Rectangle_class extends Base_tools_class {
 		if (height % 2 == 1) {
 			y -= 0.5;
 		}
+
+		var stroke_offset = !fill && ctx.lineWidth % 2 == 1 && width > 1 && height > 1 ? 0.5 : 0;
 		
+		if (smaller_dimension < 2) fill = true;
+
 		radius = {tl: radius, tr: radius, br: radius, bl: radius};
-		
 		ctx.beginPath();
-		ctx.moveTo(x + radius.tl, y);
-		ctx.lineTo(x + width - radius.tr, y);
-		ctx.quadraticCurveTo(x + width, y, x + width, y + radius.tr);
-		ctx.lineTo(x + width, y + height - radius.br);
-		ctx.quadraticCurveTo(x + width, y + height, x + width - radius.br, y + height);
-		ctx.lineTo(x + radius.bl, y + height);
-		ctx.quadraticCurveTo(x, y + height, x, y + height - radius.bl);
-		ctx.lineTo(x, y + radius.tl);
-		ctx.quadraticCurveTo(x, y, x + radius.tl, y);
+		ctx.moveTo(x + radius.tl + stroke_offset, y + stroke_offset);
+		ctx.lineTo(x + width - radius.tr - stroke_offset, y + stroke_offset);
+		ctx.quadraticCurveTo(x + width - stroke_offset, y + stroke_offset, x + width - stroke_offset, y + radius.tr + stroke_offset);
+		ctx.lineTo(x + width - stroke_offset, y + height - radius.br - stroke_offset);
+		ctx.quadraticCurveTo(x + width - stroke_offset, y + height - stroke_offset, x + width - radius.br - stroke_offset, y + height - stroke_offset);
+		ctx.lineTo(x + radius.bl + stroke_offset, y + height - stroke_offset);
+		ctx.quadraticCurveTo(x + stroke_offset, y + height - stroke_offset, x + stroke_offset, y + height - radius.bl - stroke_offset);
+		ctx.lineTo(x + stroke_offset, y + radius.tl + stroke_offset);
+		ctx.quadraticCurveTo(x + stroke_offset, y + stroke_offset, x + radius.tl + stroke_offset, y + stroke_offset);
 		ctx.closePath();
 		if (fill) {
 			ctx.fill();

--- a/src/js/tools/rectangle.js
+++ b/src/js/tools/rectangle.js
@@ -72,8 +72,8 @@ class Rectangle_class extends Base_tools_class {
 			params: this.clone(this.getParams()),
 			status: 'draft',
 			render_function: [this.name, 'render'],
-			x: mouse.x,
-			y: mouse.y,
+			x: Math.round(mouse.x),
+			y: Math.round(mouse.y),
 			is_vector: true,
 		};
 		this.Base_layers.insert(this.layer);
@@ -89,8 +89,8 @@ class Rectangle_class extends Base_tools_class {
 			return;
 		}
 
-		var width = mouse.x - this.layer.x;
-		var height = mouse.y - this.layer.y;
+		var width = Math.round(mouse.x) - this.layer.x;
+		var height = Math.round(mouse.y) - this.layer.y;
 
 		if (params.square == true) {
 			if (Math.abs(width) < Math.abs(height)) {
@@ -122,8 +122,8 @@ class Rectangle_class extends Base_tools_class {
 			return;
 		}
 
-		var width = mouse.x - this.layer.x;
-		var height = mouse.y - this.layer.y;
+		var width = Math.round(mouse.x) - this.layer.x;
+		var height = Math.round(mouse.y) - this.layer.y;
 
 		if (params.square == true) {
 			if (Math.abs(width) < Math.abs(height)) {
@@ -245,11 +245,13 @@ class Rectangle_class extends Base_tools_class {
 		radius = Math.min(radius, width / 2, height / 2);
 		radius = Math.floor(radius);
 		
-		//make it nicer
-		x = x + 0.5;
-		y = y + 0.5;
-		width--;
-		height--;
+		// Odd dimensions must draw offset half a pixel
+		if (width % 2 == 1) {
+			x -= 0.5;
+		}
+		if (height % 2 == 1) {
+			y -= 0.5;
+		}
 		
 		radius = {tl: radius, tr: radius, br: radius, bl: radius};
 		


### PR DESCRIPTION
I noticed that placing the rectangle tool is kinda shakey, and it often produces light vertical or horizontal borders depending on how exactly your mouse positions it. (at 1x zoom, undesirable for image saving)

![image](https://user-images.githubusercontent.com/4075314/101234839-e29c0b80-3690-11eb-879f-62408bdae762.png)

The problem with the tool is fairly obvious if you zoom into a low resolution image (say 3x3 pixels) and try to use it. It tries to render at non-integer positions and widths.

This PR makes placing a rectangle on the canvas more precise, and viable to use if making pixel perfect adjustments.

Additionally:
- Radius is now allowed to be 0
- getParams() in base tools returns number instead of param definition object if passing object definition for number input
- Won't create rectangles with negative width/height