### PR TITLE
Text tool causing infinite render

### DIFF
--- a/src/js/tools/text.js
+++ b/src/js/tools/text.js
@@ -1643,10 +1643,12 @@ class Text_editor_class {
 						const strikethrough = span.meta.strikethrough != null ? span.meta.strikethrough : metaDefaults.strikethrough;
 						const family = span.meta.family || metaDefaults.family;
 
-						this.load_font_family(family, () => {
-							this.hasValueChanged = true;
-							this.Base_layers.render();
-						});
+						if (fontLoadMap.get(family) !== true) {
+							this.load_font_family(family, () => {
+								this.hasValueChanged = true;
+								this.Base_layers.render();
+							});
+						}
 
 						let fontMetrics;
 						if (underline || strikethrough) {


### PR DESCRIPTION
The font family loading logic in the text tool caused the config.need_render flag to be set at every frame. This fixes that.