### PR TITLE
Search image fix - ignore same size abort

### DIFF
--- a/src/js/actions/autoresize-canvas.js
+++ b/src/js/actions/autoresize-canvas.js
@@ -11,12 +11,13 @@ export class Autoresize_canvas_action extends Base_action {
 	 * @param {int} layer_id
 	 * @param {boolean} can_automate
 	 */
-	constructor(width, height, layer_id, can_automate = true) {
+	constructor(width, height, layer_id, can_automate = true, ignore_same_size = false) {
 		super('autoresize_canvas', 'Auto-resize Canvas');
 		this.width = width;
 		this.height = height;
 		this.layer_id = layer_id;
 		this.can_automate = can_automate;
+		this.ignore_same_size = ignore_same_size;
 		this.old_config_width = null;
 		this.old_config_height = null;
 	}
@@ -59,7 +60,7 @@ export class Autoresize_canvas_action extends Base_action {
 			config.WIDTH = new_config_width;
 			config.HEIGHT = new_config_height;
 			app.GUI.prepare_canvas();
-		} else {
+		} else if (!this.ignore_same_size) {
 			throw new Error('Aborted - Resize not necessary')
 		}
 

--- a/src/js/actions/insert-layer.js
+++ b/src/js/actions/insert-layer.js
@@ -95,7 +95,7 @@ export class Insert_layer_action extends Base_action {
 						config.need_render = true;
 					};
 					layer.data = null;
-					autoresize_as = [config.layer.width, config.layer.height];
+					autoresize_as = [config.layer.width, config.layer.height, null, true, true];
 					need_autoresize = true;
 				}
 				else if (typeof layer.data == 'string') {
@@ -114,7 +114,7 @@ export class Insert_layer_action extends Base_action {
 								layer.height_original = layer.height;
 							// Free data
 							layer.data = null;
-							autoresize_as = [layer.width, layer.height, layer.id, this.can_automate];
+							autoresize_as = [layer.width, layer.height, layer.id, this.can_automate, true];
 							config.need_render = true;
 							resolve();
 						};

--- a/src/js/modules/file/open.js
+++ b/src/js/modules/file/open.js
@@ -142,7 +142,7 @@ class File_open_class {
 				app.State.do_action(
 					new app.Actions.Bundle_action('open_file_webcam', 'Open File Webcam', [
 						new app.Actions.Insert_layer_action(new_layer),
-						new app.Actions.Autoresize_canvas_action(width, height)
+						new app.Actions.Autoresize_canvas_action(width, height, null, true, true)
 					])
 				);
 				
@@ -227,7 +227,7 @@ class File_open_class {
 			app.State.do_action(
 				new app.Actions.Bundle_action('open_file_data_url', 'Open File Data URL', [
 					new app.Actions.Insert_layer_action(new_layer),
-					new app.Actions.Autoresize_canvas_action(img.width, img.height)
+					new app.Actions.Autoresize_canvas_action(img.width, img.height, null, true, true)
 				])
 			);
 			img.onload = function () {
@@ -375,6 +375,7 @@ class File_open_class {
 
 		var layer_name = url.replace(/^.*[\\\/]/, '');
 
+		console.log
 		var img = new Image();
 		img.crossOrigin = "Anonymous";
 		img.onload = function () {
@@ -393,7 +394,7 @@ class File_open_class {
 			app.State.do_action(
 				new app.Actions.Bundle_action('open_file_url', 'Open File URL', [
 					new app.Actions.Insert_layer_action(new_layer),
-					new app.Actions.Autoresize_canvas_action(img.width, img.height)
+					new app.Actions.Autoresize_canvas_action(img.width, img.height, null, true, true)
 				])
 			);
 		};


### PR DESCRIPTION
If you try to insert an image with the same dimensions of the current canvas, it was aborting the action because the resize action is set to abort on same-size resizes in order to not pollute history. Fixed the scenarios where the resize shouldn't cancel the action.