### PR TITLE
Switch to select tool after choosing a media clip

### DIFF
--- a/src/js/tools/media.js
+++ b/src/js/tools/media.js
@@ -1,3 +1,4 @@
+import app from './../app.js';
 import config from './../config.js';
 import Base_tools_class from './../core/base-tools.js';
 import File_open_class from './../modules/file/open.js';
@@ -98,6 +99,8 @@ class Media_class extends Base_tools_class {
 						};
 						_this.File_open.file_open_url_handler(data);
 						_this.POP.hide();
+
+						new app.Actions.Activate_tool_action('select', true).do();
 					});
 				}
 				var targets = popup.el.querySelectorAll('#media_paging button');


### PR DESCRIPTION
I was choosing a media item from the selection but then would always have to manually go up to the select tool before I could position it appropriately.

I wasn't sure if this was something to add to the State, but I chose to just call do on the action instead.