### PR TITLE
Update webpack.config.js to enable working via reverse proxy

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = {
 	devServer: {
 		// host: '0.0.0.0',
 		//contentBase: "./",
+		allowedHosts: 'all',
 		static: {
 			directory: path.resolve(__dirname, "./"),
 		},


### PR DESCRIPTION
Adding allowedHosts setting so that when behind a reverse proxy it doesn't complain about an invalid host header